### PR TITLE
BE-03: CRUD Boards + Columns Router

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,8 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import Base, engine
 from app.routers import auth_router
+from app.routers import boards as boards_router
+from app.routers import columns as columns_router
 
 Base.metadata.create_all(bind=engine)
 
@@ -17,3 +19,5 @@ app.add_middleware(
 )
 
 app.include_router(auth_router.router)
+app.include_router(boards_router.router)
+app.include_router(columns_router.router)

--- a/backend/app/routers/boards.py
+++ b/backend/app/routers/boards.py
@@ -1,0 +1,86 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import Board, Column, User
+from app.schemas import BoardCreate, BoardDetailResponse, BoardResponse, BoardUpdate
+
+router = APIRouter(prefix="/boards", tags=["boards"])
+
+DEFAULT_COLUMNS = [
+    ("To Do", 0),
+    ("In Progress", 1),
+    ("Done", 2),
+]
+
+
+def _get_board_or_404(board_id: int, user_id: int, db: Session) -> Board:
+    board = db.query(Board).filter(Board.id == board_id).first()
+    if board is None or board.owner_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Board not found"
+        )
+    return board
+
+
+@router.post("", response_model=BoardResponse, status_code=status.HTTP_201_CREATED)
+def create_board(
+    payload: BoardCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BoardResponse:
+    board = Board(title=payload.title, owner_id=current_user.id)
+    db.add(board)
+    db.flush()
+
+    for title, position in DEFAULT_COLUMNS:
+        db.add(Column(title=title, position=position, board_id=board.id))
+
+    db.commit()
+    db.refresh(board)
+    return BoardResponse.model_validate(board)
+
+
+@router.get("", response_model=list[BoardResponse])
+def list_boards(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[BoardResponse]:
+    boards = db.query(Board).filter(Board.owner_id == current_user.id).all()
+    return [BoardResponse.model_validate(b) for b in boards]
+
+
+@router.get("/{board_id}", response_model=BoardDetailResponse)
+def get_board(
+    board_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BoardDetailResponse:
+    board = _get_board_or_404(board_id, current_user.id, db)
+    return BoardDetailResponse.model_validate(board)
+
+
+@router.put("/{board_id}", response_model=BoardResponse)
+def update_board(
+    board_id: int,
+    payload: BoardUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BoardResponse:
+    board = _get_board_or_404(board_id, current_user.id, db)
+    board.title = payload.title
+    db.commit()
+    db.refresh(board)
+    return BoardResponse.model_validate(board)
+
+
+@router.delete("/{board_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_board(
+    board_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    board = _get_board_or_404(board_id, current_user.id, db)
+    db.delete(board)
+    db.commit()

--- a/backend/app/routers/columns.py
+++ b/backend/app/routers/columns.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import Board, Column, User
+from app.schemas import ColumnCreate, ColumnResponse, ColumnUpdate
+
+router = APIRouter(tags=["columns"])
+
+
+def _get_board_or_404(board_id: int, user_id: int, db: Session) -> Board:
+    board = db.query(Board).filter(Board.id == board_id).first()
+    if board is None or board.owner_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Board not found"
+        )
+    return board
+
+
+def _get_column_or_404(column_id: int, user_id: int, db: Session) -> Column:
+    column = db.query(Column).filter(Column.id == column_id).first()
+    if column is None or column.board.owner_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Column not found"
+        )
+    return column
+
+
+@router.post(
+    "/boards/{board_id}/columns",
+    response_model=ColumnResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_column(
+    board_id: int,
+    payload: ColumnCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ColumnResponse:
+    _get_board_or_404(board_id, current_user.id, db)
+
+    max_pos = (
+        db.query(func.max(Column.position)).filter(Column.board_id == board_id).scalar()
+    )
+    next_position = (max_pos + 1) if max_pos is not None else 0
+
+    column = Column(title=payload.title, position=next_position, board_id=board_id)
+    db.add(column)
+    db.commit()
+    db.refresh(column)
+    return ColumnResponse.model_validate(column)
+
+
+@router.put("/columns/{column_id}", response_model=ColumnResponse)
+def update_column(
+    column_id: int,
+    payload: ColumnUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ColumnResponse:
+    column = _get_column_or_404(column_id, current_user.id, db)
+    column.title = payload.title
+    db.commit()
+    db.refresh(column)
+    return ColumnResponse.model_validate(column)
+
+
+@router.delete("/columns/{column_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_column(
+    column_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    column = _get_column_or_404(column_id, current_user.id, db)
+    db.delete(column)
+    db.commit()

--- a/backend/app/routers/columns.py
+++ b/backend/app/routers/columns.py
@@ -20,8 +20,13 @@ def _get_board_or_404(board_id: int, user_id: int, db: Session) -> Board:
 
 
 def _get_column_or_404(column_id: int, user_id: int, db: Session) -> Column:
-    column = db.query(Column).filter(Column.id == column_id).first()
-    if column is None or column.board.owner_id != user_id:
+    column = (
+        db.query(Column)
+        .join(Board)
+        .filter(Column.id == column_id, Board.owner_id == user_id)
+        .first()
+    )
+    if column is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Column not found"
         )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -80,6 +80,10 @@ class ColumnCreate(BaseModel):
     title: str
 
 
+class ColumnUpdate(BaseModel):
+    title: str
+
+
 class ColumnResponse(BaseModel):
     model_config = {"from_attributes": True}
 
@@ -102,6 +106,10 @@ class ColumnWithTasksResponse(BaseModel):
 
 
 class BoardCreate(BaseModel):
+    title: str
+
+
+class BoardUpdate(BaseModel):
     title: str
 
 


### PR DESCRIPTION
## Summary

- Implementa CRUD completo para boards (`POST`, `GET`, `GET /{id}`, `PUT`, `DELETE`)
- Implementa CRUD para columns (`POST /boards/{id}/columns`, `PUT /columns/{id}`, `DELETE /columns/{id}`)
- Criação automática de 3 colunas default (To Do, In Progress, Done) ao criar um board
- Validação de ownership em todos os endpoints (404 para recursos de outros usuários)
- Cascade delete: board → columns → tasks via SQLAlchemy
- Adiciona schemas `BoardUpdate` e `ColumnUpdate` em `schemas.py`
- Registra routers em `main.py`

## Test plan

- [ ] `POST /boards` → cria board com 3 colunas default
- [ ] `GET /boards` → lista apenas boards do usuário autenticado
- [ ] `GET /boards/{id}` → retorna board com colunas e tasks, 404 para outros usuários
- [ ] `PUT /boards/{id}` → atualiza title, 404 para outros usuários
- [ ] `DELETE /boards/{id}` → deleta com cascade, 204
- [ ] `POST /boards/{id}/columns` → cria coluna com position auto-incrementado
- [ ] `PUT /columns/{id}` → atualiza title, 404 para colunas de outros usuários
- [ ] `DELETE /columns/{id}` → deleta com cascade para tasks, 204

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)