### PR TITLE
BE-05: Main App - lifespan pattern

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -7,9 +9,14 @@ from app.routers import boards as boards_router
 from app.routers import columns as columns_router
 from app.routers import tasks as tasks_router
 
-Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="Kanban API")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+app = FastAPI(title="Kanban API", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary

- Refatora `backend/app/main.py` para usar o padrão `lifespan` recomendado pelo FastAPI 0.93+
- Move `Base.metadata.create_all(bind=engine)` do nível de módulo para dentro de um `asynccontextmanager`
- Passa `lifespan=lifespan` ao construtor do `FastAPI`, eliminando o side-effect de importação

## Test plan

- [ ] Subir o servidor com `uvicorn app.main:app --reload` e verificar que as tabelas são criadas no startup
- [ ] Testar endpoints de auth, boards, columns e tasks para confirmar que continuam funcionando
- [ ] Confirmar que nenhum outro arquivo foi alterado

Closes #8

Generated with [Claude Code](https://claude.com/claude-code)